### PR TITLE
Refactoring defined or '//' to compile on older perls

### DIFF
--- a/lib/File/Scan/ClamAV.pm
+++ b/lib/File/Scan/ClamAV.pm
@@ -140,7 +140,9 @@ sub ping {
  my $conn = $self->_get_connection || return;
 
  $self->_send($conn, "PING\n");
- my $response = $conn->getline // '';
+ my $response = $conn->getline;
+ $response = '' unless defined($response);
+
  chomp($response);
 
  # Run out the buffer?


### PR DESCRIPTION
With this refactoring the distro sould pass test on perl 5.006 and 5.008
